### PR TITLE
fix(xilinx_mirrors): do not clean local_sstate_url

### DIFF
--- a/xilinx_mirrors.py
+++ b/xilinx_mirrors.py
@@ -132,7 +132,7 @@ def generate_mirrors(args, arch):
     if network_sstate == "y" and network_sstate_url:
         network_sstate_url = '\tfile://.* %s/PATH;downloadfilename=PATH \\n \\\n' % network_sstate_url
     else:
-        local_sstate_url = ''
+        network_sstate_url = ''
 
     mirrors_string += '# Sstate mirror settings\n'
     mirrors_string += 'SSTATE_MIRRORS = " \\\n%s%s"\n' % (


### PR DESCRIPTION
The `local_sstate_url` was cleaned instead of `network_sstate_url`. This removed local mirrors from `SSTATE_MIRRORS` until `NETWORK_SSTATE_FEEDS` and `NETWORK_SSTATE_FEEDS_URL` weren't set.