### PR TITLE
Bug fixes and minor code cleanups

### DIFF
--- a/gen-machineconf
+++ b/gen-machineconf
@@ -94,25 +94,25 @@ def main():
     required_args.add_argument('--hw-description', metavar='[<PATH_TO_XSA>/<xsa_name>.xsa] or <PATH_TO_SDTDIR>',
                                help='Specify Hardware(xsa) file or System Device-tree Directory',
                                )
-    optional_args.add_argument('--soc-family', metavar='',
+    optional_args.add_argument('--soc-family',
                                choices=['microblaze', 'zynq',
                                         'zynqmp', 'versal'],
                                help='SOC family type from choice list (usually auto detected).')
-    optional_args.add_argument('--soc-variant', metavar='',
+    optional_args.add_argument('--soc-variant',
                                help='SOC Variant: Ex: cg, dr, eg, ev, ai-prime, premium (usually auto detected).')
-    optional_args.add_argument('--machine-name', metavar='', dest='machine', type=str,
+    optional_args.add_argument('--machine-name', dest='machine', type=str,
                                help='Provide a name to generate machine configuration')
     optional_args.add_argument('-c', '--config-dir', metavar='<config_dir>',
                             help='Location of the build conf directory', type=os.path.realpath,
                             default=os.path.join(os.environ.get('BUILDDIR',''), 'conf'))
-    optional_args.add_argument('-r', '--require-machine', metavar='', type=str,
+    optional_args.add_argument('-r', '--require-machine', type=str,
                                help='This machine will be required, instead of the '
                                     'generic machine if defined')
-    optional_args.add_argument('-O', '--machine-overrides', metavar='', type=str,
+    optional_args.add_argument('-O', '--machine-overrides', type=str,
                                help='Provide additional overrides to the generated machine')
     optional_args.add_argument(
-        '--output', metavar='', help='Output directory name', default='')
-    optional_args.add_argument('--native-sysroot', metavar='',
+        '--output', help='Output directory name', default='')
+    optional_args.add_argument('--native-sysroot',
                                help='Native sysroot path to use the mconf/conf or lopper commands.')
     optional_args.add_argument('--menuconfig', help='UI menuconfig option '
                                'to update configuration(default is project).'
@@ -127,8 +127,7 @@ def main():
                                'to be added on top of default configs', action='append',
                                nargs='?', default=[], metavar='CONFIG_<macro>=y')
     optional_args.add_argument('--add-rootfsconfig', help='Specify a file with list of '
-                               'package names to add into rootfs menu entry',
-                               metavar='')
+                               'package names to add into rootfs menu entry')
     optional_args.add_argument(
         '-D', '--debug', help='Enable debug output', action='store_true')
 

--- a/lib/gen-machineconf/sdt_flow.py
+++ b/lib/gen-machineconf/sdt_flow.py
@@ -602,7 +602,7 @@ class sdtGenerateMultiConfigFiles(multiconfigs.GenerateMultiConfigFiles):
 
     def MicroblazeSetup(self):
         self.MBTuneFeatures()
-        if self.os_hint == 'None' or os_hint.startswith('baremetal'):
+        if self.os_hint == 'None' or self.os_hint.startswith('baremetal'):
             logger.warning(
                 'Microblaze baremetal configuration is %s not yet implemented' % self.domain)
         elif self.os_hint == 'Linux':

--- a/lib/gen-machineconf/sdt_flow.py
+++ b/lib/gen-machineconf/sdt_flow.py
@@ -713,7 +713,7 @@ def ParseSDT(args):
     if args.hw_flow == 'xsct':
         raise Exception('Invalide HW source Specified for System-Device-Tree.')
 
-    def gatherHWInfo(hw_file):
+    def gatherHWInfo():
         hw_info = {}
 
         logger.info('Getting Platform info from HW file')
@@ -795,7 +795,7 @@ def ParseSDT(args):
 
 
     #### Gather:
-    hw_info = gatherHWInfo(args.hw_file)
+    hw_info = gatherHWInfo()
 
     if hw_info['machine']:
         args.machine = hw_info['machine']

--- a/lib/project_config.py
+++ b/lib/project_config.py
@@ -122,7 +122,7 @@ def GenKconfigProj(args, system_conffile, hw_info, MCObject=None):
                         genmachine_scripts, 'configs', 'Kconfig.*'))
 
     if not os.path.isfile(Kconfig_syshw):
-        raise Exception('%s is not found in tool' % file_path)
+        raise Exception('%s is not found in tool' % Kconfig_syshw)
 
     if not os.path.isfile(system_conffile):
         common_utils.CopyFile(template_cfgfile, system_conffile)

--- a/lib/yocto_machine.py
+++ b/lib/yocto_machine.py
@@ -586,7 +586,10 @@ def GenerateYoctoMachine(args, system_conffile, plnx_syshw_file, MultiConfDict='
 
     # include soc_family machine file if user not specified.
     if not req_conf_file:
-        req_conf_file = '%s-generic' % (soc_family)
+        if args.soc_variant:
+            req_conf_file = f'{soc_family}-{args.soc_variant}-generic'
+        else:
+            req_conf_file = f'{soc_family}-generic'
         # include versal net if soc_Variant is net
         if soc_family == 'versal' and args.soc_variant == 'net':
             req_conf_file = '%s-net-generic' % (soc_family)


### PR DESCRIPTION
The two main things I wanted to fix were:

1. Stop suppressing metavars in the --help for gen-machineconf. Now it's clear which flags actually take a value. For example:

```
options:
  --soc-family {microblaze,zynq,zynqmp,versal}
                        SOC family type from choice list (usually auto detected).
  --soc-variant SOC_VARIANT
                        SOC Variant: Ex: cg, dr, eg, ev, ai-prime, premium (usually auto detected).
  --machine-name MACHINE
                        Provide a name to generate machine configuration
```

2. The SoC variant was not propagated to the Yocto MACHINE conf files. So for zynqmp, for example, you'd always end up with 'require conf/machine/zynqmp-generic.conf' even when it should be 'require conf/machine/zynqmp-eg-generic.conf'

I also noticed a few minor bugs along the way.