### PR TITLE
bugfix: AddUserLayer maintain ordering so layer dependencies work

### DIFF
--- a/lib/update_buildconf.py
+++ b/lib/update_buildconf.py
@@ -77,9 +77,9 @@ def AddUserLayers(args):
         layer_cnt += 1
 
     # Get the layers which to be add
-    add_layers = list(set(bb_layers).difference(old_layers))
+    add_layers = [l for l in bb_layers if l not in old_layers]
     # Get the layers which to be removed
-    remove_layers = list(set(old_layers).difference(bb_layers))
+    remove_layers = [l for l in old_layers if l not in bb_layers]
 
     if add_layers:
         logger.info('Adding user layers')


### PR DESCRIPTION
The order of adding/updating user layers does not maintain order so dependencies between the layers would cause the configuration to fail due to using 'set': add_layers = list(set(bb_layers).difference(old_layers))
ERROR: Layer XXX depends on layer YYY,  but this layer is not enabled in your configuration