### PR TITLE
gen-machine-conf: skip bitbake server for '--help'

### DIFF
--- a/gen-machine-conf
+++ b/gen-machine-conf
@@ -134,6 +134,11 @@ def main():
     parser._action_groups.append(optional_args)
     global_args, unparsed_args = parser.parse_known_args()
 
+    # Check if help selected
+    parserhelp = False
+    if {'-h', '--help'} & set(unparsed_args):
+        parserhelp = True
+
     parser.add_argument('-h', '--help', action='help', default=argparse.SUPPRESS,
                         help='show this help message and exit')
 
@@ -141,7 +146,8 @@ def main():
                                        dest='subcommand')
 
     # PetaLinux configuration tool skips bitbake usage
-    if 'PETALINUX' in os.environ.keys() or global_args.petalinux:
+    # -h and --help skip bitbake usage
+    if 'PETALINUX' in os.environ.keys() or global_args.petalinux or parserhelp:
         common_utils.startBitbake(disabled=True)
     else:
         # Try to start bitbake
@@ -186,11 +192,6 @@ def main():
     for plugin in plugins:
         if hasattr(plugin, 'register_commands'):
             plugin.register_commands(subparsers)
-
-    # Check if help selected to skip hw_description check
-    parserhelp = False
-    if {'-h', '--help'} & set(unparsed_args):
-        parserhelp = True
 
     # Check the hw_description description given or not.
     # Adding check here as required=True with add_argument


### PR DESCRIPTION
not necessary to start/stop the bitbake server in the case of '--help' and '-h'